### PR TITLE
feat: replace ForceRenderer with JointJS + SpringForce physics (#32)

### DIFF
--- a/packages/core/src/renderer/ForceRenderer.ts
+++ b/packages/core/src/renderer/ForceRenderer.ts
@@ -1,11 +1,23 @@
-import * as d3 from 'd3';
+/**
+ * ForceRenderer — JointJS-backed force-directed graph renderer.
+ *
+ * Replaces the D3 implementation. Internals:
+ *   - dia.Graph + dia.Paper  — render layer (replaces SvgCanvas + d3-selection)
+ *   - SpringForce            — custom spring/charge/collision physics (replaces d3-force)
+ *   - JointJS native drag    — paper interactive mode (replaces d3-drag)
+ *
+ * Public API is unchanged from the D3 version:
+ *   new ForceRenderer(container, workspace, { viewKey })
+ *   .render(viewKey?)  .update(workspace)  .destroy()
+ */
+
+import { dia } from 'jointjs';
 import type { StructurizrWorkspace, DiagramView, ContainerView, ComponentView } from '@d3c4/types';
 import { WorkspaceParser } from '../parser/WorkspaceParser.js';
 import { ViewSelector } from '../parser/ViewSelector.js';
-import { SvgCanvas } from './SvgCanvas.js';
 import type { ResolvedElement, ResolvedRelationship, ResolvedWorkspace } from '../parser/types.js';
 
-// ─── Types ───────────────────────────────────────────────────────────────────
+// ─── Public API (unchanged) ───────────────────────────────────────────────────
 
 export interface ForceRendererOptions {
   viewKey: string;
@@ -17,18 +29,28 @@ export interface ForceRendererOptions {
   onNavigate?: (viewKey: string) => void;
 }
 
-interface ForceNode extends d3.SimulationNodeDatum {
+// ─── Internal types ───────────────────────────────────────────────────────────
+
+interface PhysicsNode {
   id: string;
-  element: ResolvedElement;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
   radius: number;
+  resolvedElement: ResolvedElement;
+  cell: dia.Element;
 }
 
-interface ForceLink extends d3.SimulationLinkDatum<ForceNode> {
+interface PhysicsLink {
   id: string;
+  source: PhysicsNode;
+  target: PhysicsNode;
   relationship: ResolvedRelationship;
+  cell: dia.Link;
 }
 
-// ─── Constants ───────────────────────────────────────────────────────────────
+// ─── Constants ────────────────────────────────────────────────────────────────
 
 const RADIUS_BY_TYPE: Record<string, number> = {
   Person: 30,
@@ -41,29 +63,6 @@ function nodeRadius(el: ResolvedElement): number {
   return RADIUS_BY_TYPE[el.type] ?? 20;
 }
 
-/**
- * Clips a line between two circle centres so it starts/ends at the circle edges.
- * Adds `arrowGap` extra shortening at the target side for the arrowhead.
- */
-function clipToCircle(
-  sx: number, sy: number, sr: number,
-  tx: number, ty: number, tr: number,
-  arrowGap = 8,
-): { x1: number; y1: number; x2: number; y2: number } {
-  const dx = tx - sx;
-  const dy = ty - sy;
-  const dist = Math.sqrt(dx * dx + dy * dy) || 1;
-  const ux = dx / dist;
-  const uy = dy / dist;
-  return {
-    x1: sx + ux * sr,
-    y1: sy + uy * sr,
-    x2: tx - ux * (tr + arrowGap),
-    y2: ty - uy * (tr + arrowGap),
-  };
-}
-
-/** Returns the view key to drill into for an element, or null if none exists. */
 function findDrillDownView(element: ResolvedElement, views: DiagramView[]): string | null {
   if (element.type === 'SoftwareSystem') {
     const v = views.find(
@@ -80,11 +79,177 @@ function findDrillDownView(element: ResolvedElement, views: DiagramView[]): stri
   return null;
 }
 
-// ─── ForceRenderer ───────────────────────────────────────────────────────────
+// ─── SpringForce physics ──────────────────────────────────────────────────────
 
 /**
- * Force-directed graph renderer. Parallel to `Renderer` but uses D3 force
- * simulation instead of dagre — nodes are circles, drag feeds the physics.
+ * Minimal spring-force physics simulator — replaces d3-force.
+ *
+ * Four forces applied per tick:
+ *   1. Many-body repulsion  — pairwise Coulomb-like charge force
+ *   2. Link spring          — Hooke attraction toward rest length
+ *   3. Gravity              — soft centering toward (centerX, centerY)
+ *   4. Collision            — prevents circle overlap
+ *
+ * Alpha (simulation heat) decays from 1 to 0 over ~300 ticks.
+ * Dragged nodes are synced from their JointJS cell position rather than
+ * being integrated, so JointJS's native drag remains in control.
+ */
+class SpringForce {
+  nodes: PhysicsNode[] = [];
+  links: PhysicsLink[] = [];
+  centerX = 400;
+  centerY = 300;
+  linkRestDistance = 150;
+  chargeStrength = -800;
+  gravityStrength = 0.05;
+  collisionPadding = 10;
+
+  /** IDs of nodes currently being dragged by the user. */
+  readonly dragging = new Set<string>();
+
+  private alpha = 1.0;
+  private alphaTarget_ = 0.0;
+  // Decay rate: alpha reaches ~0.001 in ~300 ticks
+  private readonly alphaDecay = 1 - Math.pow(0.001, 1 / 300);
+  // Each step velocity is multiplied by (1 - velocityDecay) = 0.6
+  private readonly velocityDecay = 0.4;
+  private animFrame: number | null = null;
+  private tickCallback: (() => void) | null = null;
+
+  onTick(fn: () => void): this {
+    this.tickCallback = fn;
+    return this;
+  }
+
+  alphaTarget(value: number): this {
+    this.alphaTarget_ = value;
+    return this;
+  }
+
+  restart(): this {
+    // Heat up if currently cooler than target
+    if (this.alpha < this.alphaTarget_) this.alpha = this.alphaTarget_;
+    this.schedule();
+    return this;
+  }
+
+  stop(): this {
+    if (this.animFrame !== null) {
+      cancelAnimationFrame(this.animFrame);
+      this.animFrame = null;
+    }
+    return this;
+  }
+
+  private schedule(): void {
+    if (this.animFrame === null) {
+      this.animFrame = requestAnimationFrame(() => {
+        this.animFrame = null;
+        this.tick();
+        if (this.alpha >= 0.001) this.schedule();
+      });
+    }
+  }
+
+  private tick(): void {
+    const nodes = this.nodes;
+    const n = nodes.length;
+
+    // Cool alpha toward target
+    this.alpha += (this.alphaTarget_ - this.alpha) * this.alphaDecay;
+    const a = this.alpha;
+
+    // 1. Many-body repulsion — O(n²), sufficient for C4 graph sizes
+    for (let i = 0; i < n; i++) {
+      const ni = nodes[i]!;
+      for (let j = i + 1; j < n; j++) {
+        const nj = nodes[j]!;
+        const dx = nj.x - ni.x;
+        const dy = nj.y - ni.y;
+        const d2 = dx * dx + dy * dy || 1;
+        const d = Math.sqrt(d2);
+        const f = (this.chargeStrength * a) / d2;
+        const ux = dx / d;
+        const uy = dy / d;
+        ni.vx += f * ux;
+        ni.vy += f * uy;
+        nj.vx -= f * ux;
+        nj.vy -= f * uy;
+      }
+    }
+
+    // 2. Link spring — pulls connected nodes toward rest distance
+    for (const lk of this.links) {
+      const s = lk.source;
+      const t = lk.target;
+      const dx = t.x - s.x;
+      const dy = t.y - s.y;
+      const d = Math.sqrt(dx * dx + dy * dy) || 1;
+      const rest = this.linkRestDistance + s.radius + t.radius;
+      const f = ((d - rest) / d) * a;
+      s.vx += dx * f;
+      s.vy += dy * f;
+      t.vx -= dx * f;
+      t.vy -= dy * f;
+    }
+
+    // 3. Gravity — soft pull toward center
+    const gs = this.gravityStrength * a;
+    for (const nd of nodes) {
+      nd.vx += (this.centerX - nd.x) * gs;
+      nd.vy += (this.centerY - nd.y) * gs;
+    }
+
+    // 4. Collision — push overlapping circles apart
+    for (let i = 0; i < n; i++) {
+      const ni = nodes[i]!;
+      for (let j = i + 1; j < n; j++) {
+        const nj = nodes[j]!;
+        const dx = nj.x - ni.x;
+        const dy = nj.y - ni.y;
+        const d = Math.sqrt(dx * dx + dy * dy) || 1;
+        const minD = ni.radius + nj.radius + this.collisionPadding;
+        if (d < minD) {
+          const ov = ((minD - d) / d) * 0.5 * a;
+          ni.vx -= dx * ov;
+          ni.vy -= dy * ov;
+          nj.vx += dx * ov;
+          nj.vy += dy * ov;
+        }
+      }
+    }
+
+    // 5. Velocity integration
+    const vRetain = 1 - this.velocityDecay;
+    for (const nd of nodes) {
+      if (this.dragging.has(nd.id)) {
+        // Dragged node: read position from JointJS (which is managing it)
+        const pos = nd.cell.position();
+        nd.x = pos.x + nd.radius;
+        nd.y = pos.y + nd.radius;
+        nd.vx = 0;
+        nd.vy = 0;
+      } else {
+        nd.vx *= vRetain;
+        nd.vy *= vRetain;
+        nd.x += nd.vx;
+        nd.y += nd.vy;
+        // Sync JointJS element position from physics
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (nd.cell as any).set('position', { x: nd.x - nd.radius, y: nd.y - nd.radius });
+      }
+    }
+
+    this.tickCallback?.();
+  }
+}
+
+// ─── ForceRenderer ────────────────────────────────────────────────────────────
+
+/**
+ * Force-directed graph renderer. Parallel to `Renderer` but uses a custom
+ * spring force simulation instead of dagre — nodes are circles, drag feeds
+ * the physics.
  *
  * Usage:
  * ```ts
@@ -102,9 +267,18 @@ export class ForceRenderer {
 
   private parser: WorkspaceParser;
   private viewSelector: ViewSelector;
-  private svgCanvas: SvgCanvas | null = null;
-  private simulation: d3.Simulation<ForceNode, ForceLink> | null = null;
+  private graph: dia.Graph | null = null;
+  private paper: dia.Paper | null = null;
+  private physics: SpringForce | null = null;
   private tooltip: HTMLDivElement | null = null;
+
+  private physicsNodes: PhysicsNode[] = [];
+  private physicsLinks: PhysicsLink[] = [];
+  private nodeById = new Map<string, PhysicsNode>();
+  private focusedId: string | null = null;
+
+  /** Current zoom scale, maintained for tooltip positioning. */
+  private scale = 1.0;
 
   constructor(
     container: HTMLElement,
@@ -123,222 +297,130 @@ export class ForceRenderer {
 
   render(viewKey?: string): void {
     if (viewKey) this.currentViewKey = viewKey;
-    if (!this.resolved || !this.svgCanvas) return;
+    if (!this.resolved || !this.graph || !this.paper) return;
 
     try {
       const resolvedView = this.viewSelector.select(this.resolved, this.currentViewKey);
-      const canvas = this.svgCanvas.canvas;
 
-      this.simulation?.stop();
-
-      // ── Build simulation data ──────────────────────────────────────────────
-
-      const forceNodes: ForceNode[] = resolvedView.elements
-        .filter((e) => !e.boundary)
-        .map((el) => ({ id: el.id, element: el, radius: nodeRadius(el) }));
-
-      const nodeById = new Map(forceNodes.map((n) => [n.id, n]));
-
-      const forceLinks: ForceLink[] = resolvedView.relationships
-        .filter((r) => nodeById.has(r.sourceId) && nodeById.has(r.destinationId))
-        .map((r) => ({
-          id: r.id,
-          source: r.sourceId,
-          target: r.destinationId,
-          relationship: r,
-        }));
-
-      // ── DOM ───────────────────────────────────────────────────────────────
-
-      canvas.selectAll('.force-links, .force-nodes').remove();
-      const linkLayer = canvas.append('g').attr('class', 'force-links');
-      const nodeLayer = canvas.append('g').attr('class', 'force-nodes');
-
-      // Links — plain <line> elements, clipped to circle edges in tick
-      const links = linkLayer
-        .selectAll<SVGLineElement, ForceLink>('line')
-        .data(forceLinks, (d) => d.id)
-        .enter()
-        .append('line')
-        .attr('fill', 'none')
-        .attr('stroke', (d) => d.relationship.style.color)
-        .attr('stroke-width', (d) => d.relationship.style.thickness * 0.5)
-        .attr('stroke-dasharray', (d) => (d.relationship.style.dashed ? '6,3' : 'none'))
-        .attr('marker-end', (d) =>
-          this.svgCanvas!.getArrowMarkerUrl(d.relationship.style.color),
-        );
-
-      // Nodes — <g> containing circle + labels
-      const nodeGroups = nodeLayer
-        .selectAll<SVGGElement, ForceNode>('.force-node')
-        .data(forceNodes, (d) => d.id)
-        .enter()
-        .append('g')
-        .attr('class', 'force-node')
-        .attr('data-id', (d) => d.id)
-        .style('cursor', 'grab');
-
-      nodeGroups
-        .append('circle')
-        .attr('r', (d) => d.radius)
-        .attr('fill', (d) => d.element.style.background);
-
-      const labelG = nodeGroups.append('g');
-
-      labelG
-        .append('text')
-        .attr('x', (d) => d.radius + 8)
-        .attr('y', -5)
-        .attr('font-family', 'sans-serif')
-        .attr('font-size', 13)
-        .attr('font-weight', 'bold')
-        .attr('fill', '#333')
-        .text((d) => d.element.name);
-
-      labelG
-        .append('text')
-        .attr('x', (d) => d.radius + 8)
-        .attr('y', 9)
-        .attr('font-family', 'sans-serif')
-        .attr('font-size', 10)
-        .attr('fill', '#666')
-        .text((d) => {
-          const t = d.element.type === 'SoftwareSystem' ? 'Software System' : d.element.type;
-          return `[${t}]`;
-        });
-
-      // ── Interactions ──────────────────────────────────────────────────────
-
-      // Highlight: clicked node + direct neighbours; dim everything else.
-      const highlight = (focusId: string | null) => {
-        if (!focusId) {
-          nodeGroups.style('opacity', null);
-          links.style('opacity', null);
-          return;
-        }
-        const neighbourIds = new Set<string>([focusId]);
-        forceLinks.forEach((l) => {
-          const s = (l.source as ForceNode).id;
-          const t = (l.target as ForceNode).id;
-          if (s === focusId) neighbourIds.add(t);
-          if (t === focusId) neighbourIds.add(s);
-        });
-        nodeGroups.style('opacity', (d) => (neighbourIds.has(d.id) ? null : '0.15'));
-        links.style('opacity', (l) => {
-          const s = (l.source as ForceNode).id;
-          const t = (l.target as ForceNode).id;
-          return s === focusId || t === focusId ? null : '0.1';
-        });
-      };
-
-      // Click node → highlight; click background → clear
-      nodeGroups.on('click', (event, d) => {
-        event.stopPropagation();
-        const already = nodeGroups.filter((n) => n.id === d.id).classed('focused');
-        nodeGroups.classed('focused', false);
-        if (!already) {
-          d3.select(event.currentTarget as SVGGElement).classed('focused', true);
-          highlight(d.id);
-        } else {
-          highlight(null);
-        }
-        this.options.onElementClick?.(d.element);
-      });
-
-      this.svgCanvas!.svg.on('click.highlight', () => {
-        nodeGroups.classed('focused', false);
-        highlight(null);
-      });
-
-      // Hover tooltip — show on enter, update position on move, hide on leave
-      nodeGroups
-        .on('mouseenter', (_event, d) => {
-          this.showTooltip(d.element, d.x ?? 0, d.y ?? 0);
-        })
-        .on('mousemove', (_event, d) => {
-          this.showTooltip(d.element, d.x ?? 0, d.y ?? 0);
-        })
-        .on('mouseleave', () => {
-          this.hideTooltip();
-        });
-
-      // Drag — heats/cools simulation; fixes node while dragging
-      const sim = () => this.simulation;
-      nodeGroups.call(
-        d3.drag<SVGGElement, ForceNode>()
-          .on('start', function (event, d) {
-            event.sourceEvent.stopPropagation();
-            if (!event.active) sim()?.alphaTarget(0.3).restart();
-            d.fx = d.x;
-            d.fy = d.y;
-            d3.select(this).style('cursor', 'grabbing');
-          })
-          .on('drag', (_event, d) => {
-            d.fx = _event.x;
-            d.fy = _event.y;
-          })
-          .on('end', function (event, d) {
-            if (!event.active) sim()?.alphaTarget(0);
-            d.fx = null;
-            d.fy = null;
-            d3.select(this).style('cursor', 'grab');
-          }),
-      );
-
-      // Navigation — double-click to drill into related view
-      const views = this.resolved!.views;
-      const navigate = (key: string) => {
-        this.render(key);
-        this.options.onNavigate?.(key);
-      };
-      nodeGroups.each(function (d) {
-        const targetKey = findDrillDownView(d.element, views);
-        if (!targetKey) return;
-        d3.select(this)
-          .style('cursor', 'zoom-in')
-          .on('dblclick.navigate', (event) => {
-            event.stopPropagation();
-            navigate(targetKey);
-          });
-      });
-
-      // ── Force simulation ──────────────────────────────────────────────────
+      this.physics?.stop();
+      this.graph.clear();
+      this.physicsNodes = [];
+      this.physicsLinks = [];
+      this.nodeById.clear();
+      this.focusedId = null;
 
       const w = this.container.clientWidth || 800;
       const h = this.container.clientHeight || 600;
 
-      const nodeCount = forceNodes.length;
+      // ── Build nodes ────────────────────────────────────────────────────────
 
-      this.simulation = d3
-        .forceSimulation<ForceNode>(forceNodes)
-        .force(
-          'link',
-          d3.forceLink<ForceNode, ForceLink>(forceLinks)
-            .id((d) => d.id)
-            .distance((_, __, links) => 150 + (links.length * 10))
-            // .distance(nodeCount > 50 ? 80 : 150),
-        )
-        .force('charge', d3.forceManyBody<ForceNode>().strength(-1000).distanceMax(500))
-        // .force('center', d3.forceCenter(w / 2, h / 2))
-        .force('x', d3.forceX(w / 2).strength(0.05))
-        .force('y', d3.forceY(h / 2).strength(0.05))
-        .force('collide', d3.forceCollide<ForceNode>().radius((d) => d.radius + 10))
-        .on('tick', () => {
-          links.each(function (d) {
-            const s = d.source as ForceNode;
-            const t = d.target as ForceNode;
-            const { x1, y1, x2, y2 } = clipToCircle(
-              s.x ?? 0, s.y ?? 0, s.radius,
-              t.x ?? 0, t.y ?? 0, t.radius,
-            );
-            d3.select(this)
-              .attr('x1', x1).attr('y1', y1)
-              .attr('x2', x2).attr('y2', y2);
-          });
+      const elements = resolvedView.elements.filter((e) => !e.boundary);
 
-          nodeGroups.attr('transform', (d) => `translate(${d.x ?? 0}, ${d.y ?? 0})`);
-        })
-        // .alphaDecay(0.02);
+      for (const el of elements) {
+        const r = nodeRadius(el);
+        // Scatter initial positions randomly so the physics has work to do
+        const angle = Math.random() * Math.PI * 2;
+        const spread = 50 + Math.random() * 100;
+        const x = w / 2 + Math.cos(angle) * spread;
+        const y = h / 2 + Math.sin(angle) * spread;
+
+        const typeLabel = el.type === 'SoftwareSystem' ? 'Software System' : el.type;
+        const tech = (el as { technology?: string }).technology;
+        const badgeText = tech ? `[${typeLabel}: ${tech}]` : `[${typeLabel}]`;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const cell = new dia.Element({
+          position: { x: x - r, y: y - r },
+          size: { width: r * 2, height: r * 2 },
+          markup: [
+            { tagName: 'circle', selector: 'body' },
+            { tagName: 'text',   selector: 'nameLabel' },
+            { tagName: 'text',   selector: 'typeLabel' },
+          ],
+          attrs: {
+            body: {
+              cx: r,
+              cy: r,
+              r,
+              fill: el.style.background,
+              stroke: 'none',
+            },
+            nameLabel: {
+              text:       el.name,
+              x:          r * 2 + 8,
+              y:          r - 5,
+              fontFamily: 'sans-serif',
+              fontSize:   13,
+              fontWeight: 'bold',
+              fill:       '#333',
+              textAnchor: 'start',
+            },
+            typeLabel: {
+              text:       badgeText,
+              x:          r * 2 + 8,
+              y:          r + 9,
+              fontFamily: 'sans-serif',
+              fontSize:   10,
+              fill:       '#666',
+              textAnchor: 'start',
+            },
+          },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        this.graph.addCell(cell);
+
+        const node: PhysicsNode = {
+          id: el.id, x, y, vx: 0, vy: 0, radius: r, resolvedElement: el, cell,
+        };
+        this.physicsNodes.push(node);
+        this.nodeById.set(el.id, node);
+      }
+
+      // ── Build links ────────────────────────────────────────────────────────
+
+      for (const rel of resolvedView.relationships) {
+        const source = this.nodeById.get(rel.sourceId);
+        const target = this.nodeById.get(rel.destinationId);
+        if (!source || !target) continue;
+
+        const link = new dia.Link({
+          source: { id: source.cell.id },
+          target: { id: target.cell.id },
+          attrs: {
+            line: {
+              stroke:          rel.style.color,
+              strokeWidth:     rel.style.thickness * 0.5,
+              strokeDasharray: rel.style.dashed ? '6,3' : 'none',
+              targetMarker: {
+                type:   'path',
+                d:      'M 8 -4 0 0 8 4 z',
+                fill:   rel.style.color,
+                stroke: 'none',
+              },
+            },
+          },
+          router:    { name: 'straight' },
+          connector: { name: 'straight' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        this.graph.addCell(link);
+        this.physicsLinks.push({ id: rel.id, source, target, relationship: rel, cell: link });
+      }
+
+      // ── Start physics ──────────────────────────────────────────────────────
+
+      const physics = new SpringForce();
+      physics.nodes = this.physicsNodes;
+      physics.links = this.physicsLinks;
+      physics.centerX = w / 2;
+      physics.centerY = h / 2;
+      this.physics = physics;
+      physics.restart();
+
+      this.attachPaperEvents();
+
     } catch (err) {
       console.error('[d3c4] ForceRenderer error:', err);
     }
@@ -351,10 +433,13 @@ export class ForceRenderer {
   }
 
   destroy(): void {
-    this.simulation?.stop();
-    this.simulation = null;
-    this.svgCanvas?.destroy();
-    this.svgCanvas = null;
+    this.physics?.stop();
+    this.physics = null;
+    this.graph?.clear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.paper as any)?.remove();
+    this.paper = null;
+    this.graph = null;
     this.resolved = null;
     this.tooltip?.remove();
     this.tooltip = null;
@@ -362,13 +447,149 @@ export class ForceRenderer {
 
   private init(): void {
     this.resolved = this.parser.parse(this.workspace);
-    this.svgCanvas = new SvgCanvas(this.container, {
-      zoom: this.options.zoom,
-      pan: this.options.pan,
-      minZoom: this.options.minZoom,
-      maxZoom: this.options.maxZoom,
-    });
+
+    // Ensure container is positioned so absolute tooltip child works
+    if (getComputedStyle(this.container).position === 'static') {
+      this.container.style.position = 'relative';
+    }
+
+    this.graph = new dia.Graph();
+    this.paper = new dia.Paper({
+      el: this.container,
+      model: this.graph,
+      width:  this.container.clientWidth  || 800,
+      height: this.container.clientHeight || 600,
+      background: { color: '#ffffff' },
+      // Allow element drag; prevent accidental link creation from magnets
+      interactive: { elementMove: true, addLinkFromMagnet: false },
+      gridSize: 1,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    this.setupZoom();
     this.createTooltip();
+  }
+
+  /** Attach mouse-wheel zoom to the container. */
+  private setupZoom(): void {
+    if (this.options.zoom === false) return;
+    const min = this.options.minZoom ?? 0.1;
+    const max = this.options.maxZoom ?? 4.0;
+
+    this.container.addEventListener('wheel', (e) => {
+      e.preventDefault();
+      const factor = e.deltaY < 0 ? 1.1 : 0.9;
+      this.scale = Math.max(min, Math.min(max, this.scale * factor));
+      this.paper?.scale(this.scale, this.scale);
+    }, { passive: false });
+  }
+
+  /**
+   * Wire up Paper events for drag, click, hover, and navigation.
+   * Called after each render() so the current physicsNodes/Links are in scope.
+   */
+  private attachPaperEvents(): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const paper = this.paper as any;
+    const physics = this.physics!;
+
+    // Remove previously registered listeners to avoid duplicates
+    paper.off('element:pointerdown element:pointerup element:click element:dblclick element:mouseenter element:mouseleave blank:click');
+
+    const cellId = (view: unknown) => String((view as any).model?.id ?? '');
+
+    // ── Drag: heat/cool physics coupled to user interaction ────────────────
+
+    paper.on('element:pointerdown', (view: unknown) => {
+      const node = this.findNode(cellId(view));
+      if (node) {
+        physics.dragging.add(node.id);
+        physics.alphaTarget(0.3).restart();
+      }
+    });
+
+    paper.on('element:pointerup', (view: unknown) => {
+      const node = this.findNode(cellId(view));
+      if (node) {
+        physics.dragging.delete(node.id);
+        physics.alphaTarget(0);
+      }
+    });
+
+    // ── Click: toggle neighbor highlighting ────────────────────────────────
+
+    paper.on('element:click', (view: unknown) => {
+      const node = this.findNode(cellId(view));
+      if (!node) return;
+
+      if (this.focusedId === node.id) {
+        this.focusedId = null;
+        this.highlight(null);
+      } else {
+        this.focusedId = node.id;
+        this.highlight(node.id);
+      }
+      this.options.onElementClick?.(node.resolvedElement);
+    });
+
+    paper.on('blank:click', () => {
+      this.focusedId = null;
+      this.highlight(null);
+    });
+
+    // ── Hover: tooltip ─────────────────────────────────────────────────────
+
+    paper.on('element:mouseenter', (view: unknown) => {
+      const node = this.findNode(cellId(view));
+      if (node) this.showTooltip(node.resolvedElement, node.x, node.y);
+    });
+
+    paper.on('element:mouseleave', () => this.hideTooltip());
+
+    // ── Double-click: drill-down navigation ───────────────────────────────
+
+    paper.on('element:pointerdblclick', (view: unknown) => {
+      const node = this.findNode(cellId(view));
+      if (!node) return;
+      const key = findDrillDownView(node.resolvedElement, this.resolved!.views);
+      if (key) {
+        this.render(key);
+        this.options.onNavigate?.(key);
+      }
+    });
+  }
+
+  private findNode(cellId: string): PhysicsNode | null {
+    return this.physicsNodes.find((n) => (n.cell.id as string) === cellId) ?? null;
+  }
+
+  /** Dim all non-neighboring nodes and links; pass null to clear highlighting. */
+  private highlight(focusId: string | null): void {
+    const setOpacity = (cell: dia.Cell, opacity: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const v = (this.paper as any).findViewByModel(cell);
+      if (v?.el) (v.el as HTMLElement).style.opacity = opacity;
+    };
+
+    if (!focusId) {
+      for (const n of this.physicsNodes) setOpacity(n.cell, '');
+      for (const l of this.physicsLinks) setOpacity(l.cell, '');
+      return;
+    }
+
+    const neighbors = new Set([focusId]);
+    for (const l of this.physicsLinks) {
+      if (l.source.id === focusId) neighbors.add(l.target.id);
+      if (l.target.id === focusId) neighbors.add(l.source.id);
+    }
+
+    for (const n of this.physicsNodes) {
+      setOpacity(n.cell, neighbors.has(n.id) ? '' : '0.15');
+    }
+    for (const l of this.physicsLinks) {
+      const isAdj = l.source.id === focusId || l.target.id === focusId;
+      setOpacity(l.cell, isAdj ? '' : '0.1');
+    }
   }
 
   private createTooltip(): void {
@@ -385,10 +606,6 @@ export class ForceRenderer {
       'z-index:100',
       'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',
     ].join(';');
-    // Container must be position:relative/absolute for absolute child to work
-    if (getComputedStyle(this.container).position === 'static') {
-      this.container.style.position = 'relative';
-    }
     this.container.appendChild(tip);
     this.tooltip = tip;
   }
@@ -397,15 +614,10 @@ export class ForceRenderer {
     const tip = this.tooltip;
     if (!tip) return;
 
-    const bg = el.style.background;
     const fg = el.style.color || '#ffffff';
-
-    // Build badge label
     const typeLabel = el.type === 'SoftwareSystem' ? 'Software System' : el.type;
     const tech = (el as { technology?: string }).technology;
     const badgeText = tech ? `[${typeLabel}: ${tech}]` : `[${typeLabel}]`;
-
-    // Tags as pills
     const tagPills = (el.tags ?? [])
       .map((tag) => `<span style="color:white;display:inline-block;margin:2px 3px 2px 0;padding:3px 8px;border:1px solid ${fg};border-radius:4px;font-size:11px;opacity:0.85">${tag}</span>`)
       .join('');
@@ -416,35 +628,18 @@ export class ForceRenderer {
       ${el.description ? `<div style="font-size:13px;color:${fg};opacity:0.9;margin-bottom:${tagPills ? '10px' : '0'};line-height:1.45">${el.description}</div>` : ''}
       ${tagPills ? `<div style="margin-top:2px">${tagPills}</div>` : ''}
     `;
-    tip.style.background = bg;
+    tip.style.background = el.style.background;
     tip.style.display = 'block';
 
-    // Position: offset right of the node, clamped within container
-    const svgEl = this.svgCanvas!.svg.node()!;
-    const svgRect = svgEl.getBoundingClientRect();
-    const cRect = this.container.getBoundingClientRect();
-
-    // nodeX/nodeY are in SVG canvas coords; get current transform to convert to screen
-    const canvasNode = this.svgCanvas!.canvas.node()!;
-    const ctm = canvasNode.getScreenCTM();
-    if (!ctm) return;
-
-    const screenX = ctm.a * nodeX + ctm.c * nodeY + ctm.e - cRect.left;
-    const screenY = ctm.b * nodeX + ctm.d * nodeY + ctm.f - cRect.top;
-
+    // Position tooltip to the right of the node, clamped within container
+    const r = this.physicsNodes.find((n) => n.resolvedElement === el)?.radius ?? 20;
     const GAP = 16;
-    let left = screenX + GAP;
-    let top = screenY - tip.offsetHeight / 2;
-
-    // Clamp so panel stays inside the container
-    const maxLeft = this.container.clientWidth - tip.offsetWidth - 8;
-    const maxTop = this.container.clientHeight - tip.offsetHeight - 8;
-    if (left > maxLeft) left = screenX - tip.offsetWidth - GAP;
-    left = Math.max(8, left);
-    top = Math.max(8, Math.min(top, maxTop));
-
-    tip.style.left = `${left}px`;
-    tip.style.top = `${top}px`;
+    const left = (nodeX + r) * this.scale + GAP;
+    const top  = nodeY * this.scale - tip.offsetHeight / 2;
+    const maxLeft = this.container.clientWidth  - tip.offsetWidth  - 8;
+    const maxTop  = this.container.clientHeight - tip.offsetHeight - 8;
+    tip.style.left = `${Math.max(8, Math.min(left, maxLeft))}px`;
+    tip.style.top  = `${Math.max(8, Math.min(top,  maxTop))}px`;
   }
 
   private hideTooltip(): void {


### PR DESCRIPTION
## Summary

Closes #32.

Rewrites `ForceRenderer.ts` (453 lines, `d3-force` + `d3-drag` + `d3-selection`) with a self-contained JointJS implementation. The public API (`constructor`, `render`, `update`, `destroy`) is unchanged.

### What changed

**`SpringForce` class** (new, replaces `d3-force`)
- Four forces per tick: many-body repulsion (O(n²) pairwise Coulomb), link spring (Hooke), gravity (soft centering), and collision avoidance
- Alpha decay cools simulation from 1 → 0 over ~300 ticks, matching d3-force defaults
- `alphaTarget(0.3).restart()` heats the simulation on drag start; `alphaTarget(0)` cools on release

**`dia.Graph` + `dia.Paper`** (replaces `SvgCanvas` + D3 selections)
- `dia.Element` with inline `circle` + text markup for each node (no subclass needed)
- `dia.Link` with `straight` router + `targetMarker` for edges
- Paper `interactive: { elementMove: true }` handles drag natively

**Physics-coupled drag** (replaces `d3-drag`)
- `element:pointerdown` → marks node as dragged, heats simulation
- During physics tick, dragged nodes read position *from* JointJS (which owns the drag); other nodes write position *to* JointJS
- `element:pointerup` → unmarks node, cools simulation

**Preserved behaviours**
- Neighbor highlighting on click (toggle; click same node again to clear)
- Hover tooltip with name, badge, description, and tag pills
- Double-click drill-down navigation
- Wheel-event zoom with scale bounds

**`d3-force` and `d3-drag` are no longer imported by this file.**

## Test plan

- [ ] Existing test suite passes (`pnpm test`)
- [ ] Force layout visually separates nodes with charge repulsion and link attraction
- [ ] Dragging a node heats the simulation — connected nodes react in real time
- [ ] Releasing a node cools the simulation — layout settles
- [ ] Clicking a node dims non-neighbours; clicking again clears highlighting
- [ ] Hovering shows the tooltip with correct content
- [ ] Double-clicking a SoftwareSystem navigates to its ContainerView