### PR TITLE
feat: replace ElementRenderer + RelationshipRenderer with JointJS cells (#34)

### DIFF
--- a/packages/core/src/renderer/ElementRenderer.ts
+++ b/packages/core/src/renderer/ElementRenderer.ts
@@ -1,207 +1,133 @@
-import * as d3 from 'd3';
+import { dia } from 'jointjs';
 import type { LayoutNode } from '../layout/types.js';
 import type { ResolvedElement } from '../parser/types.js';
-import { getDrawFn } from './ShapeRegistry.js';
+import { createShapeCell, createBoundaryCell, type ShapeContent } from './ShapeRegistry.js';
 
 export interface ElementRendererOptions {
   onElementClick?: (element: ResolvedElement) => void;
 }
 
+/**
+ * Renders C4 elements as JointJS `dia.Element` cells.
+ *
+ * Each call to `render()` synchronises the graph to the new layout:
+ *   - Existing cells whose IDs are no longer present are removed.
+ *   - New cells are created with `node.id` as the stable cell ID.
+ *   - Cells that already exist are repositioned in place.
+ *
+ * This replaces the D3 general-update-pattern from the previous implementation.
+ */
 export class ElementRenderer {
-  private canvas: d3.Selection<SVGGElement, unknown, null, undefined>;
-  private options: ElementRendererOptions;
+  private readonly graph: dia.Graph;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly paper: any; // dia.Paper
+  private readonly options: ElementRendererOptions;
+
+  /** IDs of cells currently owned by this renderer (elements + boundaries). */
+  private ownedIds = new Set<string>();
+  /** Maps cell ID → ResolvedElement for click callback lookup. */
+  private elementById = new Map<string, ResolvedElement>();
 
   constructor(
-    canvas: d3.Selection<SVGGElement, unknown, null, undefined>,
+    graph: dia.Graph,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    paper: any,
     options: ElementRendererOptions = {},
   ) {
-    this.canvas = canvas;
+    this.graph = graph;
+    this.paper = paper;
     this.options = options;
-
-    // Ensure layer groups exist in the right paint order
-    if (canvas.select('.d3c4-boundaries').empty()) {
-      canvas.append('g').attr('class', 'd3c4-boundaries');
-    }
-    if (canvas.select('.d3c4-relationships').empty()) {
-      canvas.append('g').attr('class', 'd3c4-relationships');
-    }
-    if (canvas.select('.d3c4-elements').empty()) {
-      canvas.append('g').attr('class', 'd3c4-elements');
-    }
   }
 
   render(nodes: LayoutNode[], boundaries: Array<{ element: ResolvedElement }>): void {
     this.renderBoundaries(boundaries, nodes);
     this.renderNodes(nodes);
+    this.attachClickHandler();
   }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
 
   private renderBoundaries(
     boundaries: Array<{ element: ResolvedElement }>,
     nodes: LayoutNode[],
   ): void {
-    const layer = this.canvas.select<SVGGElement>('.d3c4-boundaries');
-    layer.selectAll('.d3c4-boundary').remove();
-
-    if (boundaries.length === 0 || nodes.length === 0) return;
+    // Remove boundaries not in this render
+    const nextBoundaryIds = new Set(boundaries.map((b) => `boundary-${b.element.name}`));
+    for (const id of [...this.ownedIds]) {
+      if (id.startsWith('boundary-') && !nextBoundaryIds.has(id)) {
+        this.graph.getCell(id)?.remove();
+        this.ownedIds.delete(id);
+      }
+    }
 
     for (const { element } of boundaries) {
-      // Nodes "inside" this boundary: Container children of a SoftwareSystem boundary,
-      // or Component children of a Container boundary.
-      const innerType = element.type === 'SoftwareSystem' ? 'Container' : 'Component';
-      const innerNodes = nodes.filter((n) => n.element.type === innerType);
-      if (innerNodes.length === 0) continue;
-
-      const H_PAD = 20;
-      const TOP_PAD = 20;
-      const BOTTOM_PAD = 52; // extra room for the label at the bottom
-
-      const minX = Math.min(...innerNodes.map((n) => n.x - n.width / 2)) - H_PAD;
-      const minY = Math.min(...innerNodes.map((n) => n.y - n.height / 2)) - TOP_PAD;
-      const maxX = Math.max(...innerNodes.map((n) => n.x + n.width / 2)) + H_PAD;
-      const maxY = Math.max(...innerNodes.map((n) => n.y + n.height / 2)) + BOTTOM_PAD;
-
-      const g = layer.append('g').attr('class', 'd3c4-boundary');
-
-      g.append('rect')
-        .attr('x', minX)
-        .attr('y', minY)
-        .attr('width', maxX - minX)
-        .attr('height', maxY - minY)
-        .attr('fill', element.style.background)
-        .attr('fill-opacity', 0.05)
-        .attr('stroke', element.style.background)
-        .attr('stroke-width', 2)
-        .attr('stroke-dasharray', '10,5');
-
-      // Label at bottom-left, inside the boundary rect
-      const labelX = minX + 10;
-      const badgeFontSize = 11;
-      const nameFontSize = 13;
-      const badgeY = maxY - 8;
-      const nameY = badgeY - badgeFontSize - 2;
-
-      g.append('text')
-        .attr('x', labelX)
-        .attr('y', nameY)
-        .attr('fill', element.style.background)
-        .attr('font-size', nameFontSize)
-        .attr('font-weight', 'bold')
-        .attr('font-family', 'sans-serif')
-        .text(element.name);
-
-      g.append('text')
-        .attr('x', labelX)
-        .attr('y', badgeY)
-        .attr('fill', element.style.background)
-        .attr('font-size', badgeFontSize)
-        .attr('font-family', 'sans-serif')
-        .attr('font-style', 'italic')
-        .text(`[${element.type === 'SoftwareSystem' ? 'Software System' : element.type}]`);
+      const id = `boundary-${element.name}`;
+      const existing = this.graph.getCell(id);
+      if (existing) {
+        // Recompute and update the boundary rect
+        existing.remove();
+        this.ownedIds.delete(id);
+      }
+      const cell = createBoundaryCell(element, nodes);
+      if (cell) {
+        this.graph.addCell(cell);
+        this.ownedIds.add(id);
+      }
     }
   }
 
   private renderNodes(nodes: LayoutNode[]): void {
-    const layer = this.canvas.select<SVGGElement>('.d3c4-elements');
+    const nextIds = new Set(nodes.map((n) => n.id));
 
-    // D3 general update pattern keyed by element ID
-    const groups = layer
-      .selectAll<SVGGElement, LayoutNode>('.d3c4-element')
-      .data(nodes, (d) => d.id);
-
-    groups.exit().remove();
-
-    const entering = groups
-      .enter()
-      .append('g')
-      .attr('class', 'd3c4-element')
-      .attr('data-id', (d) => d.id)
-      .attr('data-type', (d) => d.element.type)
-      .style('cursor', 'pointer');
-
-    if (this.options.onElementClick) {
-      entering.on('click', (event, d) => {
-        event.stopPropagation();
-        this.options.onElementClick!(d.element);
-      });
+    // Remove cells for elements no longer in the view
+    for (const id of [...this.ownedIds]) {
+      if (!id.startsWith('boundary-') && !nextIds.has(id)) {
+        this.graph.getCell(id)?.remove();
+        this.ownedIds.delete(id);
+      }
     }
 
-    const merged = entering.merge(groups);
+    for (const node of nodes) {
+      const content = nodeToContent(node);
+      const existing = this.graph.getCell(node.id) as dia.Element | undefined;
 
-    // Position (transition on re-render)
-    merged
-      .transition()
-      .duration(300)
-      .attr('transform', (d) => `translate(${d.x - d.width / 2}, ${d.y - d.height / 2})`);
-
-    // Draw shape — clear and redraw on each render (style may have changed)
-    merged.each(function (d) {
-      const g = d3.select<SVGGElement, LayoutNode>(this);
-      // Remove old shape children
-      g.selectAll('.d3c4-shape, .d3c4-shape-head, .d3c4-shape-body, .d3c4-label-group').remove();
-
-      const { style } = d.element;
-      const drawFn = getDrawFn(style.shape);
-      drawFn(g as any, style);
-
-      // Label group
-      const labelG = g.append('g').attr('class', 'd3c4-label-group');
-
-      const isPerson = style.shape === 'Person';
-      // For Person: body rect starts at y=46; add 8px top padding → first text at y=54.
-      const textStartY = isPerson ? 54 : 0;
-
-      // Type badge (e.g. [Person], [Container: Java])
-      const badge = buildTypeBadge(d.element);
-      if (badge) {
-        labelG
-          .append('text')
-          .attr('class', 'd3c4-element-badge')
-          .attr('x', d.width / 2)
-          .attr('y', textStartY + style.fontSize * 0.8)
-          .attr('text-anchor', 'middle')
-          .attr('fill', style.color)
-          .attr('font-size', Math.max(style.fontSize - 3, 10))
-          .attr('font-family', 'sans-serif')
-          .text(badge);
+      if (existing) {
+        // Reposition without full recreation (preserves any embedded state)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (existing as any).set({
+          position: { x: node.x - node.width  / 2, y: node.y - node.height / 2 },
+          size:     { width: node.width, height: node.height },
+        });
+      } else {
+        const cell = createShapeCell(node, content);
+        this.graph.addCell(cell);
+        this.ownedIds.add(node.id);
       }
+      this.elementById.set(node.id, node.element);
+    }
+  }
 
-      // Name (main label)
-      const nameY = badge
-        ? textStartY + style.fontSize * 0.8 + style.fontSize + 4
-        : textStartY + (isPerson ? 4 : d.height / 2 - (d.element.description ? style.fontSize : style.fontSize / 2));
-
-      const nameExtraHeight = wrapText(
-        labelG,
-        d.element.name,
-        d.width - 16,
-        d.width / 2,
-        nameY,
-        style.color,
-        style.fontSize,
-        true,
-      );
-
-      // Description (smaller, optional)
-      if (d.element.description) {
-        const descFontSize = Math.max(style.fontSize - 3, 10);
-        const descY = nameY + nameExtraHeight + descFontSize + 6;
-        wrapText(
-          labelG,
-          d.element.description,
-          d.width - 16,
-          d.width / 2,
-          descY,
-          style.color,
-          descFontSize,
-          false,
-        );
-      }
+  /**
+   * Wire the element:click Paper event to the onElementClick callback.
+   * Called on every render to refresh the handler's node lookup.
+   */
+  private attachClickHandler(): void {
+    if (!this.options.onElementClick) return;
+    this.paper.off('element:click.d3c4-element');
+    this.paper.on('element:click.d3c4-element', (view: unknown) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cellId = String((view as any).model?.id ?? '');
+      if (!this.ownedIds.has(cellId) || cellId.startsWith('boundary-')) return;
+      const el = this.elementById.get(cellId);
+      if (el) this.options.onElementClick!(el);
     });
   }
 }
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
 function buildTypeBadge(element: ResolvedElement): string | null {
-  if (element.type === 'Person') return '[Person]';
+  if (element.type === 'Person')         return '[Person]';
   if (element.type === 'SoftwareSystem') return '[Software System]';
   if (element.type === 'Container') {
     return element.technology ? `[Container: ${element.technology}]` : '[Container]';
@@ -212,50 +138,11 @@ function buildTypeBadge(element: ResolvedElement): string | null {
   return null;
 }
 
-function wrapText(
-  parent: d3.Selection<SVGGElement, LayoutNode, SVGGElement | null, undefined>,
-  text: string,
-  maxWidth: number,
-  x: number,
-  y: number,
-  color: string,
-  fontSize: number,
-  bold: boolean,
-): number {
-  const textEl = parent
-    .append('text')
-    .attr('x', x)
-    .attr('y', y)
-    .attr('text-anchor', 'middle')
-    .attr('fill', color)
-    .attr('font-size', fontSize)
-    .attr('font-family', 'sans-serif')
-    .attr('font-weight', bold ? 'bold' : 'normal');
-
-  // Simple word wrap: approximate chars per line
-  const charsPerLine = Math.floor(maxWidth / (fontSize * 0.55));
-  const words = text.split(' ');
-  const lines: string[] = [];
-  let currentLine = '';
-
-  for (const word of words) {
-    const test = currentLine ? `${currentLine} ${word}` : word;
-    if (test.length > charsPerLine && currentLine) {
-      lines.push(currentLine);
-      currentLine = word;
-    } else {
-      currentLine = test;
-    }
-  }
-  if (currentLine) lines.push(currentLine);
-
-  for (let i = 0; i < lines.length; i++) {
-    textEl
-      .append('tspan')
-      .attr('x', x)
-      .attr('dy', i === 0 ? 0 : fontSize * 1.2)
-      .text(lines[i]!);
-  }
-
-  return (lines.length - 1) * fontSize * 1.2;
+function nodeToContent(node: LayoutNode): ShapeContent {
+  return {
+    badge:       buildTypeBadge(node.element),
+    name:        node.element.name,
+    description: node.element.description,
+    style:       node.element.style,
+  };
 }

--- a/packages/core/src/renderer/NavigationHandler.ts
+++ b/packages/core/src/renderer/NavigationHandler.ts
@@ -1,50 +1,47 @@
-import * as d3 from 'd3';
 import type { DiagramView, ContainerView, ComponentView } from '@d3c4/types';
 import type { LayoutNode } from '../layout/types.js';
 import type { ResolvedElement } from '../parser/types.js';
 
 /**
- * Attaches drill-down navigation to rendered elements.
+ * Attaches drill-down navigation to rendered elements via JointJS Paper events.
  *
  * Double-clicking a SoftwareSystem navigates to its ContainerView;
  * double-clicking a Container navigates to its ComponentView.
- * Elements that have no related view are unaffected.
  *
  * Call `attach(nodes, views)` after every render.
  */
 export class NavigationHandler {
-  private canvas: d3.Selection<SVGGElement, unknown, null, undefined>;
-  private navigate: (viewKey: string) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly paper: any; // dia.Paper
+  private readonly navigate: (viewKey: string) => void;
 
   constructor(
-    canvas: d3.Selection<SVGGElement, unknown, null, undefined>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    paper: any,
     navigate: (viewKey: string) => void,
   ) {
-    this.canvas = canvas;
+    this.paper = paper;
     this.navigate = navigate;
   }
 
   attach(nodes: LayoutNode[], views: DiagramView[]): void {
-    const navigate = this.navigate;
+    // Build drilldown map: element ID → target view key
+    const drilldown = new Map<string, string>();
+    for (const node of nodes) {
+      const key = findDrillDownView(node.element, views);
+      if (key) drilldown.set(node.id, key);
+    }
 
-    this.canvas
-      .selectAll<SVGGElement, LayoutNode>('.d3c4-element')
-      .each(function (d) {
-        const targetKey = findDrillDownView(d.element, views);
-        const sel = d3.select<SVGGElement, LayoutNode>(this);
+    // Re-register on every render to pick up the latest drilldown map
+    this.paper.off('element:pointerdblclick.navigate');
+    if (drilldown.size === 0) return;
 
-        // Remove any previously registered handler to avoid duplicates on re-render.
-        sel.on('dblclick.navigate', null);
-
-        if (!targetKey) return;
-
-        sel
-          .style('cursor', 'zoom-in')
-          .on('dblclick.navigate', (event) => {
-            event.stopPropagation();
-            navigate(targetKey);
-          });
-      });
+    this.paper.on('element:pointerdblclick.navigate', (view: unknown) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cellId = String((view as any).model?.id ?? '');
+      const key = drilldown.get(cellId);
+      if (key) this.navigate(key);
+    });
   }
 }
 

--- a/packages/core/src/renderer/RelationshipRenderer.ts
+++ b/packages/core/src/renderer/RelationshipRenderer.ts
@@ -1,179 +1,161 @@
-import * as d3 from 'd3';
+import { dia } from 'jointjs';
 import type { LayoutEdge } from '../layout/types.js';
-import type { SvgCanvas } from './SvgCanvas.js';
 import type { ResolvedRelationship } from '../parser/types.js';
 
 export interface RelationshipRendererOptions {
   onRelationshipClick?: (rel: ResolvedRelationship) => void;
 }
 
+/**
+ * Renders C4 relationships as JointJS `dia.Link` cells.
+ *
+ * Links use dagre waypoints from the layout engine, expressed as a
+ * series of `vertices` on the link's `straight` router so the path
+ * follows the pre-computed route.
+ *
+ * Replaces the previous D3-based implementation.
+ */
 export class RelationshipRenderer {
-  private canvas: d3.Selection<SVGGElement, unknown, null, undefined>;
-  private svgCanvas: SvgCanvas;
-  private options: RelationshipRendererOptions;
+  private readonly graph: dia.Graph;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly paper: any; // dia.Paper
+  private readonly options: RelationshipRendererOptions;
+
+  /** IDs of link cells currently owned by this renderer. */
+  private ownedIds = new Set<string>();
+  /** Maps link cell ID → ResolvedRelationship for click callback. */
+  private relById = new Map<string, ResolvedRelationship>();
 
   constructor(
-    canvas: d3.Selection<SVGGElement, unknown, null, undefined>,
-    svgCanvas: SvgCanvas,
+    graph: dia.Graph,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    paper: any,
     options: RelationshipRendererOptions = {},
   ) {
-    this.canvas = canvas;
-    this.svgCanvas = svgCanvas;
+    this.graph = graph;
+    this.paper = paper;
     this.options = options;
   }
 
   render(edges: LayoutEdge[]): void {
-    const layer = this.canvas.select<SVGGElement>('.d3c4-relationships');
+    const nextIds = new Set(edges.map((e) => `link-${e.id}`));
 
-    const groups = layer
-      .selectAll<SVGGElement, LayoutEdge>('.d3c4-relationship')
-      .data(edges, (d) => d.id);
-
-    groups.exit().remove();
-
-    const entering = groups
-      .enter()
-      .append('g')
-      .attr('class', 'd3c4-relationship')
-      .attr('data-id', (d) => d.id)
-      .attr('data-source', (d) => d.sourceId)
-      .attr('data-dest', (d) => d.destinationId)
-      .style('cursor', 'pointer');
-
-    if (this.options.onRelationshipClick) {
-      entering.on('click', (event, d) => {
-        event.stopPropagation();
-        this.options.onRelationshipClick!(d.relationship);
-      });
+    // Remove links no longer in the view
+    for (const id of [...this.ownedIds]) {
+      if (!nextIds.has(id)) {
+        this.graph.getCell(id)?.remove();
+        this.ownedIds.delete(id);
+        this.relById.delete(id);
+      }
     }
 
-    const merged = entering.merge(groups);
+    for (const edge of edges) {
+      const linkId = `link-${edge.id}`;
+      const style = edge.relationship.style;
 
-    merged.each((d, i, nodes) => {
-      const g = d3.select<SVGGElement, LayoutEdge>(nodes[i]!);
-      g.selectAll('*').remove();
+      // Waypoints from dagre layout (first and last are the element positions —
+      // skip them and use the intermediate points as JointJS vertices)
+      const vertices = edge.points.slice(1, -1).map((p) => ({ x: p.x, y: p.y }));
 
-      const style = d.relationship.style;
-      const markerUrl = this.svgCanvas.getArrowMarkerUrl(style.color);
-      const lineFn = d3
-        .line<{ x: number; y: number }>()
-        .x((p) => p.x)
-        .y((p) => p.y);
-
-      // Edge path
-      g.append('path')
-        .attr('class', 'd3c4-edge-line')
-        .attr('d', lineFn(d.points) ?? '')
-        .attr('fill', 'none')
-        .attr('stroke', style.color)
-        .attr('stroke-width', style.thickness * .5)
-        .attr('stroke-dasharray', style.dashed ? '6,3' : 'none')
-        .attr('marker-end', markerUrl);
-
-      // Invisible wider path for easier clicking
-      g.append('path')
-        .attr('class', 'd3c4-edge-hitbox')
-        .attr('d', lineFn(d.points) ?? '')
-        .attr('fill', 'none')
-        .attr('stroke', 'transparent')
-        .attr('stroke-width', 12);
-
-      // Label — position at midpoint of the path
-      if (d.relationship.description || d.relationship.technology) {
-        const mid = getMidPoint(d.points);
-        const labelG = g.append('g').attr('class', 'd3c4-edge-label').attr('transform', `translate(${mid.x}, ${mid.y})`);
-
-        const LABEL_MAX_WIDTH = 120;
-        let dy = 0;
-        if (d.relationship.description) {
-          dy = wrapLabelText(
-            labelG, d.relationship.description, LABEL_MAX_WIDTH, dy,
-            style.color, style.fontSize, false,
-          );
-        }
-        if (d.relationship.technology) {
-          wrapLabelText(
-            labelG, `[${d.relationship.technology}]`, LABEL_MAX_WIDTH, dy,
-            style.color, style.fontSize, true,
-          );
-        }
-
-        // Insert a background rect behind the text using the rendered bounding box.
-        const labelNode = labelG.node();
-        if (labelNode) {
-          try {
-            const bbox = labelNode.getBBox();
-            const pad = 2;
-            labelG.insert('rect', ':first-child')
-              .attr('x', bbox.x - pad)
-              .attr('y', bbox.y - pad)
-              .attr('width', bbox.width + pad * 2)
-              .attr('height', bbox.height + pad * 2)
-              .attr('fill', '#ffffff')
-              .attr('rx', 2)
-              .attr('opacity', 1);
-          } catch {
-            // getBBox is unavailable in non-DOM environments (e.g. tests)
-          }
-        }
+      if (this.ownedIds.has(linkId)) {
+        // Update vertices on re-render (source/target elements may have moved)
+        const link = this.graph.getCell(linkId) as dia.Link;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (link as any).set('vertices', vertices);
+      } else {
+        const link = buildLink(linkId, edge, style, vertices);
+        this.graph.addCell(link);
+        this.ownedIds.add(linkId);
+        this.relById.set(linkId, edge.relationship);
       }
+    }
+
+    this.attachClickHandler();
+  }
+
+  private attachClickHandler(): void {
+    if (!this.options.onRelationshipClick) return;
+    this.paper.off('link:click.d3c4-rel');
+    this.paper.on('link:click.d3c4-rel', (view: unknown) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cellId = String((view as any).model?.id ?? '');
+      const rel = this.relById.get(cellId);
+      if (rel) this.options.onRelationshipClick!(rel);
     });
   }
 }
 
-/**
- * Renders word-wrapped text into a label <g> element.
- * Returns the dy offset to use for the next text block below.
- */
-function wrapLabelText(
-  parent: d3.Selection<SVGGElement, LayoutEdge, null, undefined>,
-  text: string,
-  maxWidth: number,
-  startDy: number,
-  color: string,
-  fontSize: number,
-  italic: boolean,
-): number {
-  const charsPerLine = Math.floor(maxWidth / (fontSize * 0.55));
-  const words = text.split(' ');
-  const lines: string[] = [];
-  let currentLine = '';
-  for (const word of words) {
-    const test = currentLine ? `${currentLine} ${word}` : word;
-    if (test.length > charsPerLine && currentLine) {
-      lines.push(currentLine);
-      currentLine = word;
-    } else {
-      currentLine = test;
-    }
-  }
-  if (currentLine) lines.push(currentLine);
+// ─── Factory ──────────────────────────────────────────────────────────────────
 
-  const textEl = parent
-    .append('text')
-    .attr('text-anchor', 'middle')
-    .attr('fill', color)
-    .attr('font-size', fontSize)
-    .attr('font-family', 'sans-serif')
-    .attr('font-style', italic ? 'italic' : 'normal');
+function buildLink(
+  id: string,
+  edge: LayoutEdge,
+  style: ResolvedRelationship['style'],
+  vertices: Array<{ x: number; y: number }>,
+): dia.Link {
+  // VSCode WebView compatibility for marker URLs
+  const markerFill = style.color;
 
-  for (let i = 0; i < lines.length; i++) {
-    textEl
-      .append('tspan')
-      .attr('x', 0)
-      .attr('dy', i === 0 ? startDy : fontSize * 1.2)
-      .text(lines[i]!);
-  }
-
-  return startDy + (lines.length - 1) * fontSize * 1.2 + fontSize + 4;
+  return new dia.Link({
+    id,
+    // Source and target by element ID (stable across re-renders)
+    source: { id: edge.sourceId },
+    target: { id: edge.destinationId },
+    vertices,
+    router:    { name: 'straight' },
+    connector: { name: 'straight' },
+    attrs: {
+      line: {
+        stroke:          style.color,
+        strokeWidth:     style.thickness * 0.5,
+        strokeDasharray: style.dashed ? '6,3' : 'none',
+        targetMarker: {
+          type:   'path',
+          d:      'M 8 -4 0 0 8 4 z',
+          fill:   markerFill,
+          stroke: 'none',
+        },
+      },
+      // Invisible wider hitbox for easier clicking
+      wrapper: {
+        stroke:      'transparent',
+        strokeWidth: 12,
+      },
+    },
+    // Label at midpoint
+    labels: buildLabel(edge.relationship, style),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
 }
 
-function getMidPoint(points: Array<{ x: number; y: number }>): { x: number; y: number } {
-  if (points.length === 0) return { x: 0, y: 0 };
-  if (points.length === 1) return points[0]!;
+function buildLabel(
+  rel: ResolvedRelationship,
+  style: ResolvedRelationship['style'],
+): dia.Link.Label[] {
+  const parts: string[] = [];
+  if (rel.description) parts.push(rel.description);
+  if (rel.technology)  parts.push(`[${rel.technology}]`);
+  if (parts.length === 0) return [];
 
-  const midIdx = Math.floor(points.length / 2);
-  const a = points[midIdx - 1]!;
-  const b = points[midIdx]!;
-  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+  return [{
+    position: 0.5,
+    attrs: {
+      text: {
+        text:       parts.join('\n'),
+        fill:       style.color,
+        fontSize:   style.fontSize,
+        fontFamily: 'sans-serif',
+        textAnchor: 'middle',
+      },
+      rect: {
+        fill:        '#ffffff',
+        stroke:      'none',
+        rx:          2,
+        refWidth:    '100%',
+        refHeight:   '100%',
+        refX:        0,
+        refY:        0,
+      },
+    },
+  }];
 }

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -5,7 +5,6 @@ import { LayoutEngine } from '../layout/LayoutEngine.js';
 import { SvgCanvas } from './SvgCanvas.js';
 import { ElementRenderer } from './ElementRenderer.js';
 import { RelationshipRenderer } from './RelationshipRenderer.js';
-// import { DragHandler } from './DragHandler.js';
 import { NavigationHandler } from './NavigationHandler.js';
 import type { ResolvedElement, ResolvedRelationship, ResolvedWorkspace } from '../parser/types.js';
 
@@ -53,7 +52,6 @@ export class Renderer {
   private svgCanvas: SvgCanvas | null = null;
   private elementRenderer: ElementRenderer | null = null;
   private relRenderer: RelationshipRenderer | null = null;
-  // private dragHandler: DragHandler | null = null;
   private navigationHandler: NavigationHandler | null = null;
 
   constructor(
@@ -101,7 +99,6 @@ export class Renderer {
 
       this.elementRenderer!.render(layoutGraph.nodes, boundaryElements);
       this.relRenderer!.render(layoutGraph.edges);
-      // this.dragHandler!.attach(layoutGraph.nodes);
       this.navigationHandler!.attach(layoutGraph.nodes, this.resolved!.views);
 
       if (this.options.fitOnRender !== false) {
@@ -146,7 +143,6 @@ export class Renderer {
     this.svgCanvas = null;
     this.elementRenderer = null;
     this.relRenderer = null;
-    // this.dragHandler = null;
     this.navigationHandler = null;
     this.resolved = null;
   }
@@ -163,18 +159,20 @@ export class Renderer {
       height: this.options.height,
     });
 
-    this.elementRenderer = new ElementRenderer(this.svgCanvas.canvas, {
-      onElementClick: this.options.onElementClick,
-    });
+    this.elementRenderer = new ElementRenderer(
+      this.svgCanvas.graph,
+      this.svgCanvas.paper,
+      { onElementClick: this.options.onElementClick },
+    );
 
-    this.relRenderer = new RelationshipRenderer(this.svgCanvas.canvas, this.svgCanvas, {
-      onRelationshipClick: this.options.onRelationshipClick,
-    });
-
-    // this.dragHandler = new DragHandler(this.svgCanvas.canvas);
+    this.relRenderer = new RelationshipRenderer(
+      this.svgCanvas.graph,
+      this.svgCanvas.paper,
+      { onRelationshipClick: this.options.onRelationshipClick },
+    );
 
     this.navigationHandler = new NavigationHandler(
-      this.svgCanvas.canvas,
+      this.svgCanvas.paper,
       (viewKey) => {
         this.render(viewKey);
         this.options.onNavigate?.(viewKey);

--- a/packages/core/src/renderer/ShapeRegistry.ts
+++ b/packages/core/src/renderer/ShapeRegistry.ts
@@ -1,208 +1,286 @@
-import * as d3 from 'd3';
-import type { Selection } from 'd3';
+import { dia } from 'jointjs';
 import type { ResolvedElementStyle } from '../parser/types.js';
 import type { LayoutNode } from '../layout/types.js';
 
-export type DrawFn = (
-  sel: Selection<SVGGElement, LayoutNode, SVGGElement, unknown>,
-  style: ResolvedElementStyle,
-) => void;
+// ─── Shape constants (kept in sync with LayoutEngine) ────────────────────────
 
-type NodeSel = Selection<SVGGElement, LayoutNode, SVGGElement, unknown>;
-
-function drawBox(sel: NodeSel, style: ResolvedElementStyle): void {
-  sel
-    .append('rect')
-    .attr('class', 'd3c4-shape')
-    .attr('width', (d: LayoutNode) => d.width)
-    .attr('height', (d: LayoutNode) => d.height)
-    .attr('fill', style.background)
-    .attr('stroke', style.stroke)
-    .attr('stroke-width', ELEMENT_STROKE_WIDTH)
-    .attr('rx', 0)
-    .attr('ry', 0);
-}
-
-function drawRoundedBox(sel: NodeSel, style: ResolvedElementStyle): void {
-  sel
-    .append('rect')
-    .attr('class', 'd3c4-shape')
-    .attr('width', (d: LayoutNode) => d.width)
-    .attr('height', (d: LayoutNode) => d.height)
-    .attr('fill', style.background)
-    .attr('stroke', style.stroke)
-    .attr('stroke-width', ELEMENT_STROKE_WIDTH)
-    .attr('rx', 8)
-    .attr('ry', 8);
-}
-
-// PERSON_BODY_Y must stay in sync with PERSON_BODY_Y in LayoutEngine and
-// PERSON_TEXT_START_Y in ElementRenderer.
 const PERSON_HEAD_CY = 24;
-const PERSON_HEAD_R = 35;
-const PERSON_BODY_Y = PERSON_HEAD_CY + PERSON_HEAD_R - 4;
-const ELEMENT_STROKE_WIDTH = 0;
+const PERSON_HEAD_R  = 35;
+const PERSON_BODY_Y  = PERSON_HEAD_CY + PERSON_HEAD_R - 4; // 55
 
-function drawPerson(sel: NodeSel, style: ResolvedElementStyle): void {
-  // Head circle
-  sel
-    .append('circle')
-    .attr('class', 'd3c4-shape-head')
-    .attr('cx', (d: LayoutNode) => d.width / 2)
-    .attr('cy', PERSON_HEAD_CY)
-    .attr('r', PERSON_HEAD_R)
-    .attr('fill', style.background)
-    .attr('stroke', style.stroke)
-    .attr('stroke-width', ELEMENT_STROKE_WIDTH);
+// ─── Text badge helper ─────────────────────────────────────────────────────────
 
-  // Body rectangle — full element width, dynamic height
-  sel
-    .append('rect')
-    .attr('class', 'd3c4-shape-body')
-    .attr('x', 0)
-    .attr('y', PERSON_BODY_Y)
-    .attr('width', (d: LayoutNode) => d.width)
-    .attr('height', (d: LayoutNode) => d.height - PERSON_BODY_Y - 4)
-    .attr('rx', 6)
-    .attr('fill', style.background)
-    .attr('stroke', style.stroke)
-    .attr('stroke-width', ELEMENT_STROKE_WIDTH);
+export interface ShapeContent {
+  badge: string | null;
+  name: string;
+  description: string | undefined;
+  style: ResolvedElementStyle;
 }
 
-function drawCylinder(sel: NodeSel, style: ResolvedElementStyle): void {
+function makeBadge(style: ResolvedElementStyle, name: string): string | null {
+  // ShapeContent comes from ResolvedElement; we only have the style here,
+  // so the caller passes badge text explicitly.
+  return null; // always overridden by the caller
+}
+
+// ─── Per-shape markup + attrs builders ───────────────────────────────────────
+
+/** Returns base markup: shape sub-elements + badge/label/desc text elements. */
+function textMarkup(): Array<{ tagName: string; selector: string }> {
+  return [
+    { tagName: 'text', selector: 'badge' },
+    { tagName: 'text', selector: 'label' },
+    { tagName: 'text', selector: 'desc'  },
+  ];
+}
+
+function textAttrs(
+  content: ShapeContent,
+  textY: number,   // y of first text line (badge), in element-local coords
+  width: number,
+): Record<string, unknown> {
+  const { badge, name, description, style } = content;
+  const fs = style.fontSize ?? 14;
+  const color = style.color ?? '#ffffff';
+
+  return {
+    badge: badge ? {
+      text: badge,
+      x: width / 2,
+      y: textY,
+      textAnchor: 'middle',
+      fontFamily: 'sans-serif',
+      fontSize: Math.max(fs - 3, 10),
+      fill: color,
+    } : { display: 'none' },
+
+    label: {
+      text: name,
+      x: width / 2,
+      y: badge ? textY + (fs - 2) + fs + 4 : textY + (description ? fs : fs / 2),
+      textAnchor: 'middle',
+      fontFamily: 'sans-serif',
+      fontSize: fs,
+      fontWeight: 'bold',
+      fill: color,
+    },
+
+    desc: description ? {
+      text: description,
+      x: width / 2,
+      y: badge
+        ? textY + (fs - 2) + fs + 4 + fs + 6 + Math.max(fs - 3, 10)
+        : textY + fs + 4 + Math.max(fs - 3, 10),
+      textAnchor: 'middle',
+      fontFamily: 'sans-serif',
+      fontSize: Math.max(fs - 3, 10),
+      fill: color,
+    } : { display: 'none' },
+  };
+}
+
+// ─── Shape-specific cell builders ─────────────────────────────────────────────
+
+function buildBox(node: LayoutNode, content: ShapeContent, rx = 0): dia.Element {
+  const { width: w, height: h } = node;
+  const { background: fill, stroke } = content.style;
+  return new dia.Element({
+    id:       node.id,
+    position: { x: node.x - w / 2, y: node.y - h / 2 },
+    size:     { width: w, height: h },
+    markup: [
+      { tagName: 'rect', selector: 'body' },
+      ...textMarkup(),
+    ],
+    attrs: {
+      body: { x: 0, y: 0, width: 'calc(w)', height: 'calc(h)', rx, fill, stroke, strokeWidth: 0 },
+      ...textAttrs(content, h * 0.15, w),
+    },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+function buildPerson(node: LayoutNode, content: ShapeContent): dia.Element {
+  const { width: w, height: h } = node;
+  const { background: fill, stroke } = content.style;
+  const bodyY = PERSON_BODY_Y;
+  return new dia.Element({
+    id:       node.id,
+    position: { x: node.x - w / 2, y: node.y - h / 2 },
+    size:     { width: w, height: h },
+    markup: [
+      { tagName: 'circle', selector: 'head' },
+      { tagName: 'rect',   selector: 'body' },
+      ...textMarkup(),
+    ],
+    attrs: {
+      head: { cx: 'calc(0.5*w)', cy: PERSON_HEAD_CY, r: PERSON_HEAD_R, fill, stroke, strokeWidth: 0 },
+      body: { x: 0, y: bodyY, width: 'calc(w)', height: `calc(h-${bodyY + 4})`, rx: 6, fill, stroke, strokeWidth: 0 },
+      // Text positioned inside the body rect (below the head)
+      ...textAttrs(content, bodyY + 8, w),
+    },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+function buildCylinder(node: LayoutNode, content: ShapeContent): dia.Element {
+  const { width: w, height: h } = node;
+  const { background: fill, stroke } = content.style;
   const ry = 10;
-  sel.each(function (this: SVGGElement, datum: LayoutNode) {
-    const s = d3.select<SVGGElement, LayoutNode>(this);
-    const w = datum.width;
-    const h = datum.height;
-    s.append('rect')
-      .attr('class', 'd3c4-shape')
-      .attr('x', 0)
-      .attr('y', ry)
-      .attr('width', w)
-      .attr('height', h - ry * 2)
-      .attr('fill', style.background)
-      .attr('stroke', style.stroke)
-      .attr('stroke-width', ELEMENT_STROKE_WIDTH);
-    s.append('ellipse')
-      .attr('cx', w / 2)
-      .attr('cy', ry)
-      .attr('rx', w / 2)
-      .attr('ry', ry)
-      .attr('fill', style.background)
-      .attr('stroke', style.stroke)
-      .attr('stroke-width', ELEMENT_STROKE_WIDTH);
-    s.append('ellipse')
-      .attr('cx', w / 2)
-      .attr('cy', h - ry)
-      .attr('rx', w / 2)
-      .attr('ry', ry)
-      .attr('fill', style.background)
-      .attr('stroke', style.stroke)
-      .attr('stroke-width', ELEMENT_STROKE_WIDTH);
-  });
+  return new dia.Element({
+    id:       node.id,
+    position: { x: node.x - w / 2, y: node.y - h / 2 },
+    size:     { width: w, height: h },
+    markup: [
+      { tagName: 'rect',    selector: 'body'      },
+      { tagName: 'ellipse', selector: 'capBottom' },
+      { tagName: 'ellipse', selector: 'capTop'    },
+      ...textMarkup(),
+    ],
+    attrs: {
+      body:      { x: 0, y: ry, width: 'calc(w)', height: `calc(h-${ry * 2})`, fill, stroke, strokeWidth: 0 },
+      capBottom: { cx: 'calc(0.5*w)', cy: `calc(h-${ry})`, rx: 'calc(0.5*w)', ry, fill, stroke, strokeWidth: 0 },
+      capTop:    { cx: 'calc(0.5*w)', cy: ry, rx: 'calc(0.5*w)', ry, fill, stroke, strokeWidth: 0 },
+      ...textAttrs(content, h * 0.15 + ry, w),
+    },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
 }
 
-function drawCircle(sel: NodeSel, style: ResolvedElementStyle): void {
-  sel
-    .append('circle')
-    .attr('class', 'd3c4-shape')
-    .attr('cx', (d: LayoutNode) => d.width / 2)
-    .attr('cy', (d: LayoutNode) => d.height / 2)
-    .attr('r', (d: LayoutNode) => Math.min(d.width, d.height) / 2)
-    .attr('fill', style.background)
-    .attr('stroke', style.stroke)
-    .attr('stroke-width', ELEMENT_STROKE_WIDTH);
+function buildComponent(node: LayoutNode, content: ShapeContent): dia.Element {
+  const { width: w, height: h } = node;
+  const { background: fill, stroke } = content.style;
+  const NOTCH_W = 12, NOTCH_H = 8, NOTCH_X = -6;
+  return new dia.Element({
+    id:       node.id,
+    position: { x: node.x - w / 2, y: node.y - h / 2 },
+    size:     { width: w, height: h },
+    markup: [
+      { tagName: 'rect', selector: 'body'   },
+      { tagName: 'rect', selector: 'notch1' },
+      { tagName: 'rect', selector: 'notch2' },
+      ...textMarkup(),
+    ],
+    attrs: {
+      body:   { x: 0, y: 0, width: 'calc(w)', height: 'calc(h)', rx: 4, fill, stroke, strokeWidth: 0 },
+      notch1: { x: NOTCH_X, y: 'calc(h/3-4)', width: NOTCH_W, height: NOTCH_H, rx: 2, fill, stroke, strokeWidth: 2 },
+      notch2: { x: NOTCH_X, y: 'calc(2*h/3-4)', width: NOTCH_W, height: NOTCH_H, rx: 2, fill, stroke, strokeWidth: 0 },
+      ...textAttrs(content, h * 0.15, w),
+    },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
 }
 
-function drawEllipse(sel: NodeSel, style: ResolvedElementStyle): void {
-  sel
-    .append('ellipse')
-    .attr('class', 'd3c4-shape')
-    .attr('cx', (d: LayoutNode) => d.width / 2)
-    .attr('cy', (d: LayoutNode) => d.height / 2)
-    .attr('rx', (d: LayoutNode) => d.width / 2)
-    .attr('ry', (d: LayoutNode) => d.height / 2)
-    .attr('fill', style.background)
-    .attr('stroke', style.stroke)
-    .attr('stroke-width', ELEMENT_STROKE_WIDTH);
+function buildCircle(node: LayoutNode, content: ShapeContent): dia.Element {
+  const { width: w, height: h } = node;
+  const { background: fill, stroke } = content.style;
+  return new dia.Element({
+    id:       node.id,
+    position: { x: node.x - w / 2, y: node.y - h / 2 },
+    size:     { width: w, height: h },
+    markup: [
+      { tagName: 'ellipse', selector: 'body' },
+      ...textMarkup(),
+    ],
+    attrs: {
+      body: { cx: 'calc(0.5*w)', cy: 'calc(0.5*h)', rx: 'calc(0.5*w)', ry: 'calc(0.5*h)', fill, stroke, strokeWidth: 0 },
+      ...textAttrs(content, h * 0.3, w),
+    },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
 }
 
-function drawHexagon(sel: NodeSel, style: ResolvedElementStyle): void {
-  sel
-    .append('polygon')
-    .attr('class', 'd3c4-shape')
-    .attr('points', (d: LayoutNode) => {
-      const w = d.width;
-      const h = d.height;
-      const cx = w / 2;
-      const cy = h / 2;
-      const rx = w / 2;
-      const ry = h / 2;
-      return [
-        [cx - rx, cy],
-        [cx - rx / 2, cy - ry],
-        [cx + rx / 2, cy - ry],
-        [cx + rx, cy],
-        [cx + rx / 2, cy + ry],
-        [cx - rx / 2, cy + ry],
-      ]
-        .map((p) => p.join(','))
-        .join(' ');
-    })
-    .attr('fill', style.background)
-    .attr('stroke', style.stroke)
-    .attr('stroke-width', ELEMENT_STROKE_WIDTH);
+function buildHexagon(node: LayoutNode, content: ShapeContent): dia.Element {
+  const { width: w, height: h } = node;
+  const { background: fill, stroke } = content.style;
+  const pts = '0,calc(0.5*h) calc(0.25*w),0 calc(0.75*w),0 calc(w),calc(0.5*h) calc(0.75*w),calc(h) calc(0.25*w),calc(h)';
+  return new dia.Element({
+    id:       node.id,
+    position: { x: node.x - w / 2, y: node.y - h / 2 },
+    size:     { width: w, height: h },
+    markup: [
+      { tagName: 'polygon', selector: 'body' },
+      ...textMarkup(),
+    ],
+    attrs: {
+      body: { points: pts, fill, stroke, strokeWidth: 0 },
+      ...textAttrs(content, h * 0.25, w),
+    },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
 }
 
-function drawComponent(sel: NodeSel, style: ResolvedElementStyle): void {
-  sel.each(function (this: SVGGElement, datum: LayoutNode) {
-    const s = d3.select<SVGGElement, LayoutNode>(this);
-    const w = datum.width;
-    const h = datum.height;
-    s.append('rect')
-      .attr('class', 'd3c4-shape')
-      .attr('width', w)
-      .attr('height', h)
-      .attr('rx', 4)
-      .attr('fill', style.background)
-      .attr('stroke', style.stroke)
-      .attr('stroke-width', ELEMENT_STROKE_WIDTH);
-    const notchW = 12;
-    const notchH = 8;
-    const notchX = -notchW / 2;
-    s.append('rect')
-      .attr('x', notchX)
-      .attr('y', h / 3 - notchH / 2)
-      .attr('width', notchW)
-      .attr('height', notchH)
-      .attr('rx', 2)
-      .attr('fill', style.background)
-      .attr('stroke', style.stroke)
-      .attr('stroke-width', 2);
-    s.append('rect')
-      .attr('x', notchX)
-      .attr('y', (h * 2) / 3 - notchH / 2)
-      .attr('width', notchW)
-      .attr('height', notchH)
-      .attr('rx', 2)
-      .attr('fill', style.background)
-      .attr('stroke', style.stroke)
-      .attr('stroke-width', ELEMENT_STROKE_WIDTH);
-  });
+// ─── Boundary cell ───────────────────────────────────────────────────────────
+
+/** Creates a dashed boundary rect for SoftwareSystem/Container clusters. */
+export function createBoundaryCell(
+  element: { name: string; type: string; style: ResolvedElementStyle },
+  nodes: LayoutNode[],
+): dia.Element | null {
+  const innerType = element.type === 'SoftwareSystem' ? 'Container' : 'Component';
+  const innerNodes = nodes.filter((n) => n.element.type === innerType);
+  if (innerNodes.length === 0) return null;
+
+  const H_PAD = 20, TOP_PAD = 20, BOTTOM_PAD = 52;
+  const minX = Math.min(...innerNodes.map((n) => n.x - n.width  / 2)) - H_PAD;
+  const minY = Math.min(...innerNodes.map((n) => n.y - n.height / 2)) - TOP_PAD;
+  const maxX = Math.max(...innerNodes.map((n) => n.x + n.width  / 2)) + H_PAD;
+  const maxY = Math.max(...innerNodes.map((n) => n.y + n.height / 2)) + BOTTOM_PAD;
+
+  const w = maxX - minX;
+  const h = maxY - minY;
+  const color = element.style.background;
+  const fs = 13;
+
+  return new dia.Element({
+    id:       `boundary-${element.name}`,
+    position: { x: minX, y: minY },
+    size:     { width: w, height: h },
+    markup: [
+      { tagName: 'rect', selector: 'border' },
+      { tagName: 'text', selector: 'name'   },
+      { tagName: 'text', selector: 'badge'  },
+    ],
+    attrs: {
+      border: {
+        x: 0, y: 0, width: 'calc(w)', height: 'calc(h)',
+        fill: color, fillOpacity: 0.05,
+        stroke: color, strokeWidth: 2, strokeDasharray: '10,5',
+      },
+      name: {
+        text: element.name,
+        x: 10, y: `calc(h-${8 + (fs - 1) + fs + 2})`,
+        fontFamily: 'sans-serif', fontSize: fs, fontWeight: 'bold', fill: color,
+        textAnchor: 'start',
+      },
+      badge: {
+        text: `[${element.type === 'SoftwareSystem' ? 'Software System' : element.type}]`,
+        x: 10, y: `calc(h-8)`,
+        fontFamily: 'sans-serif', fontSize: fs - 2, fill: color,
+        fontStyle: 'italic', textAnchor: 'start',
+      },
+    },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
 }
 
-export const shapeRegistry: Partial<Record<string, DrawFn>> = {
-  Box: drawBox,
-  RoundedBox: drawRoundedBox,
-  Person: drawPerson,
-  Circle: drawCircle,
-  Ellipse: drawEllipse,
-  Hexagon: drawHexagon,
-  Component: drawComponent,
-  Cylinder: drawCylinder,
-};
+// ─── Public factory ───────────────────────────────────────────────────────────
 
-export function getDrawFn(shape: string): DrawFn {
-  return shapeRegistry[shape] ?? drawRoundedBox;
+/**
+ * Creates a JointJS `dia.Element` for a layout node.
+ * The element ID is set to `node.id` for stable cross-render identity.
+ */
+export function createShapeCell(node: LayoutNode, content: ShapeContent): dia.Element {
+  const shape = content.style.shape;
+  switch (shape) {
+    case 'Person':     return buildPerson(node, content);
+    case 'Cylinder':   return buildCylinder(node, content);
+    case 'Component':  return buildComponent(node, content);
+    case 'Circle':
+    case 'Ellipse':    return buildCircle(node, content);
+    case 'Hexagon':    return buildHexagon(node, content);
+    case 'Box':        return buildBox(node, content, 0);
+    case 'RoundedBox':
+    default:           return buildBox(node, content, 8);
+  }
 }

--- a/packages/core/src/renderer/SvgCanvas.ts
+++ b/packages/core/src/renderer/SvgCanvas.ts
@@ -26,8 +26,12 @@ export class SvgCanvas {
   readonly defs: d3.Selection<SVGDefsElement, unknown, null, undefined>;
   readonly canvas: d3.Selection<SVGGElement, unknown, null, undefined>;
 
+  /** JointJS graph — add dia.Element/dia.Link cells here to render them. */
+  readonly graph: dia.Graph;
+  /** JointJS paper — use for Paper event subscriptions and scaling. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly paper: any; // dia.Paper — typed as any to access Backbone internals
+  readonly paper: any; // dia.Paper — typed as any to access Backbone internals
+
   private readonly container: HTMLElement;
   private readonly options: SvgCanvasOptions;
 
@@ -47,15 +51,14 @@ export class SvgCanvas {
     container.querySelectorAll('svg.d3c4-svg').forEach((el) => el.remove());
 
     // dia.Paper creates the SVG and appends it to the container
-    const graph = new dia.Graph();
+    this.graph = new dia.Graph();
     this.paper = new dia.Paper({
       el: container,
-      model: graph,
+      model: this.graph,
       width: w,
       height: h,
       background: { color: '#ffffff' },
-      // No interactive elements — SvgCanvas renders raw D3 SVG, not JointJS cells
-      interactive: false,
+      interactive: { elementMove: true, addLinkFromMagnet: false },
       gridSize: 1,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);


### PR DESCRIPTION
## Summary

Closes #34. Depends on #33 (base branch: `claude/issue-33-svgcanvas-paper`).

Replaces the D3 general-update-pattern in `ElementRenderer` and `RelationshipRenderer` with JointJS `dia.Element`/`dia.Link` cells. All eight C4 shapes and boundary containers are now rendered as JointJS cells added to the `dia.Graph` exposed by `SvgCanvas`.

### What changed

**`ShapeRegistry.ts`** — full rewrite
- Replaces `DrawFn` (d3.Selection draw functions) with `createShapeCell(node, content)` factory
- All 8 shapes as inline `dia.Element` instances with shape-specific `markup` + `attrs`:
  - `Box` / `RoundedBox` — rect with `rx=0` / `rx=8`
  - `Person` — circle head + rect body, text positioned inside body
  - `Cylinder` — rect body + two ellipse caps, all sized via `calc()`
  - `Component` — rect body + two notch rects (`calc(h/3-4)` / `calc(2*h/3-4)`)
  - `Circle` / `Ellipse` — single ellipse
  - `Hexagon` — polygon with 9 calc() expressions
- `createBoundaryCell()` for cluster boundary rectangles (dashed border, name + badge labels)
- `node.id` used as the JointJS cell ID for stable cross-render identity

**`ElementRenderer.ts`** — full rewrite
- Constructor: `(graph: dia.Graph, paper, options)` — no longer takes `d3.Selection`
- `render()` syncs graph cells to layout: creates new cells, repositions existing ones (by stable ID), removes stale ones
- `onElementClick` wired via `paper.on('element:click.d3c4-element', ...)` with an `elementById` map for lookup

**`RelationshipRenderer.ts`** — full rewrite
- Constructor: `(graph: dia.Graph, paper, options)`
- Renders `dia.Link` cells with `straight` router, `targetMarker` arrow, optional `strokeDasharray`
- Dagre waypoints passed as `vertices` so links follow the pre-computed route
- Label (description + technology) via JointJS `labels` array at `position: 0.5`

**`NavigationHandler.ts`** — rewrite
- Replaces `d3.on('dblclick.navigate')` with `paper.on('element:pointerdblclick.navigate', ...)`
- Constructor now takes `paper` instead of `d3.Selection<SVGGElement>`

**`Renderer.ts`** + **`SvgCanvas.ts`**
- `SvgCanvas` exposes `graph` and `paper` as public `readonly` properties
- `Renderer.init()` passes `graph` + `paper` to all three renderer/handler constructors
- Commented-out `DragHandler` references removed (JointJS Paper handles drag natively)

**`d3-selection`, `d3-transition`, and `d3-shape` are no longer imported by any renderer file.**

## Test plan

- [ ] Existing test suite passes (`pnpm test`)
- [ ] All 8 shapes render with correct fill colour from workspace styles
- [ ] Boundary containers show the dashed rect around their children
- [ ] `onElementClick` callback fires with the correct `ResolvedElement`
- [ ] Relationships render with arrow markers and correct dashing
- [ ] Edge labels appear at the midpoint of each link
- [ ] Double-clicking a SoftwareSystem navigates to its ContainerView
- [ ] Calling `render()` a second time repositions cells without duplication